### PR TITLE
Suggestions for docs/rearranging

### DIFF
--- a/changelog.d/3305.doc.rst
+++ b/changelog.d/3305.doc.rst
@@ -1,1 +1,0 @@
-Updated the example pyproject.toml -- by :user:`jacalata`

--- a/changelog.d/3405.doc.rst
+++ b/changelog.d/3405.doc.rst
@@ -1,0 +1,1 @@
+Rearrange top-level documentation pages -- by :user:`jacalata`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,6 +100,9 @@ intersphinx_mapping.update({
     'importlib-resources': (
         'https://importlib-resources.readthedocs.io/en/latest', None
     ),
+    'importlib-metadata': (
+        'https://importlib-metadata.readthedocs.io/en/latest', None
+    )
 })
 
 # Add support for linking usernames
@@ -184,11 +187,6 @@ nitpick_ignore = [
     # TODO: check https://docutils.rtfd.io in the future
     ('py:mod', 'docutils'),  # there's no Sphinx site documenting this
 ]
-
-# Allow linking objects on other Sphinx sites seamlessly:
-intersphinx_mapping.update(
-    python=('https://docs.python.org/3', None),
-)
 
 # Add support for the unreleased "next-version" change notes
 extensions += ['sphinxcontrib.towncrier']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,6 +116,7 @@ extlinks = {
     'user': (f'{github_sponsors_url}/%s', '@%s'),  # noqa: WPS323
     'pypi': ('https://pypi.org/project/%s', '%s'),  # noqa: WPS323
     'wiki': ('https://wikipedia.org/wiki/%s', '%s'),  # noqa: WPS323
+    'RTD': ('https://%s.readthedocs.io', '%s'),  # noqa: WPS323
 }
 extensions += ['sphinx.ext.extlinks']
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,7 @@ extensions += ['sphinx_reredirects']
 redirects = {
     "userguide/keywords": "/deprecated/changed_keywords.html",
     "userguide/commands": "/deprecated/commands.html",
-    "setuptools": "index"
+    "setuptools": "/index.html"
 }
 
 # Add support for inline tabs

--- a/docs/deprecated/former_api.rst
+++ b/docs/deprecated/former_api.rst
@@ -1,0 +1,43 @@
+Deprecated, Obsolete or Removed Setuptools APIs
+===============================================
+
+The following ``setuptools`` APIs are no longer considered available for public use.
+
+
+Configuration and Metadata Parsing
+----------------------------------
+.. deprecated:: 61.0.0
+
+.. currentmodule:: setuptools.config
+
+.. function:: read_configuration(path, find_others=False, ignore_option_errors=False)
+
+Some automation tools may wish to access data from a configuration file.
+``Setuptools`` exposes a ``read_configuration()`` function for
+parsing ``metadata`` and ``options`` sections into a dictionary:
+
+.. code-block:: python
+
+    from setuptools.config import read_configuration
+    conf_dict = read_configuration("/home/user/dev/package/setup.cfg")
+
+
+By default, ``read_configuration()`` will read only the file provided
+in the first argument. To include values from other configuration files
+which could be in various places, set the ``find_others`` keyword argument
+to ``True``.
+If you have only a configuration file but not the whole package, you can still
+try to get data out of it with the help of the ``ignore_option_errors`` keyword
+argument. When it is set to ``True``, all options with errors possibly produced
+by directives, such as ``attr:`` and others, will be silently ignored.
+As a consequence, the resulting dictionary will include no such options.
+
+.. admonition:: Alternatives for ``setuptools.config``
+
+   Consider parsing the ``setup.cfg`` directly using the :class:`~configparser.ConfigParser`
+   class available on Python's standard library.
+   To access metadata from ``setuptools`` based projects you can also try
+   the functionalities exposed by the :pypi:`build` package (e.g.
+   :func:`build.util.project_wheel_metadata`, or
+   :meth:`build.ProjectBuilder.prepare` combined with
+   :meth:`importlib_metadata.Distribution.at`).

--- a/docs/deprecated/functionalities.rst
+++ b/docs/deprecated/functionalities.rst
@@ -31,30 +31,3 @@ order to ensure that, once running, ``pkg_resources`` will know what project
 and version is in use.  The header script will check this and exit with an
 error if the ``.egg`` file has been renamed or is invoked via a symlink that
 changes its base name.
-
-
-
-Configuration API
-=================
-
-.. deprecated:: 61.0.0
-
-Some automation tools may wish to access data from a configuration file.
-``Setuptools`` exposes a ``read_configuration()`` function for
-parsing ``metadata`` and ``options`` sections into a dictionary::
-
-.. code-block::	python
-
-	from setuptools.config import read_configuration
-	conf_dict = read_configuration("/home/user/dev/package/setup.cfg")
-
-
-By default, ``read_configuration()`` will read only the file provided
-in the first argument. To include values from other configuration files
-which could be in various places, set the ``find_others`` keyword argument
-to ``True``.
-If you have only a configuration file but not the whole package, you can still
-try to get data out of it with the help of the ``ignore_option_errors`` keyword
-argument. When it is set to ``True``, all options with errors possibly produced
-by directives, such as ``attr:`` and others, will be silently ignored.
-As a consequence, the resulting dictionary will include no such options.

--- a/docs/deprecated/functionalities.rst
+++ b/docs/deprecated/functionalities.rst
@@ -1,5 +1,5 @@
 "Eggsecutable" Scripts
-=================
+======================
 
 .. deprecated:: 45.3.0
 

--- a/docs/deprecated/functionalities.rst
+++ b/docs/deprecated/functionalities.rst
@@ -37,7 +37,7 @@ changes its base name.
 Configuration API
 =================
 
-.. deprecated:: ????
+.. deprecated:: 61.0.0
 
 Some automation tools may wish to access data from a configuration file.
 ``Setuptools`` exposes a ``read_configuration()`` function for

--- a/docs/deprecated/index.rst
+++ b/docs/deprecated/index.rst
@@ -13,6 +13,7 @@ objectives.
 .. toctree::
     :maxdepth: 1
 
+    origins
     changed_keywords
     dependency_links
     python_eggs
@@ -23,4 +24,4 @@ objectives.
     distutils-legacy
     functionalities
     commands
-    setuptools_api
+    former_api

--- a/docs/deprecated/index.rst
+++ b/docs/deprecated/index.rst
@@ -23,3 +23,4 @@ objectives.
     distutils-legacy
     functionalities
     commands
+    setuptools_api

--- a/docs/deprecated/origins.rst
+++ b/docs/deprecated/origins.rst
@@ -1,0 +1,67 @@
+========================
+The origin of Setuptools
+========================
+
+``Setuptools`` started out as a collection of enhancements to the
+distutils_ module in Python's standard library,
+allowing developers to more easily build and distribute Python
+packages, especially the ones with dependencies on other packages.
+
+Packages built and distributed using ``setuptools`` initially looked to the user like
+ordinary Python packages based on the ``distutils``.
+
+The main enhancements implemented in ``setuptools`` were:
+
+* Ability to create `Python Eggs <http://peak.telecommunity.com/DevCenter/PythonEggs>`_ -
+  a single-file importable distribution format
+
+* Enhanced support for accessing data files hosted in zipped packages.
+
+* Automatically inclusion of all packages in the source tree, without listing them
+  individually in setup.py
+
+* Automatically inclusion of all relevant files in source distributions,
+  without needing to create a |MANIFEST.in|_ file, and without having to force
+  regeneration of the ``MANIFEST`` file when your source tree changes
+  [#manifest]_.
+
+* Automatically generation of wrapper scripts or Windows (console and GUI) .exe
+  files for any number of "main" functions in a project.  (Note: this was not
+  a py2exe replacement; the .exe files rely on the local Python installation.)
+
+* Transparent Cython support, so that ``setup.py`` can list ``.pyx`` files and
+  still work even when the end-user doesn't have Cython installed (as long as
+  the Cython-generated C files are included in the source distribution)
+
+* Command aliases - project-specific, per-user, or site-wide shortcut
+  names for commonly used commands and options
+
+* Support for "development mode", such that it's available on
+  ``sys.path``, yet can still be edited directly from its source checkout.
+
+* Ability to add new ``distutils`` commands or ``setup()`` arguments, and distribute/
+  reuse extensions for multiple projects, without copying code.
+
+* Ability to create extensible applications and frameworks that automatically discover
+  extensions, using simple "entry points" declared in a project's setup script.
+
+* Full support for PEP 420 via ``find_namespace_packages()``
+  (backwards compatible to the existing ``find_packages()`` for Python >= 3.3).
+
+* Ability to build projects using configuration and metadata
+  provided via ``setup.cfg`` without the need of an imperative ``setup.py``
+  script (introduced in version 40.9.0).
+
+----
+
+
+.. [#manifest] The default behaviour for ``setuptools`` will work well for pure
+   Python packages, or packages with simple C extensions (that don't require
+   any special C header). See :ref:`Controlling files in the distribution` and
+   :doc:`/userguide/datafiles` for more information about complex scenarios, if
+   you want to include other types of files.
+
+.. |MANIFEST.in| replace:: ``MANIFEST.in``
+.. _MANIFEST.in: https://packaging.python.org/en/latest/guides/using-manifest-in/
+
+.. _distutils: https://docs.python.org/3.9/library/distutils.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,43 +1,29 @@
 .. image:: images/banner-640x320.svg
    :align: center
 
-About
-=============
-
 Setuptools is a fully-featured, actively-maintained, and stable library designed for
-packaging Python projects. It helps developers to easily share Python/Cython libraries,
-tools and and applications in standard formats (sdist, bdist, wheel..) that can be
+packaging Python projects. It helps developers to easily share Python libraries,
+tools and applications in standard formats that can be
 uploaded to `PyPI <http://pypi.org>`_ and installed with :pypi:`pip`.
 
-For a long time it was the semi-official replacement for distutils, and de facto
-specification for package management/bundling/installation, using *setup.py*/*setup.cfg*.
-In the build system/model established by PEP 517/518, it is a **build backend**, and since
-:pep:`621` the files *setup.py/setup.cfg* are deprecated and are being replaced by configuration
-with ``pyproject.toml``
+For a long time it was the semi-official replacement for ``distutils`` and de facto
+specification for Python package management, bundling and installation.
+In the build system model standardized in recent years by the Python community,
+``setuptools`` is a modern *build backend* that supports interoperable
+configuration via ``pyproject.toml``.
+
+Setuptools has an active third party plugin ecosystem which includes
+:pypi:`setuptools-scm`, :pypi:`setuptools-svn`, :pypi:`setuptools-rust`
+and :pypi:`setuptools-golang`. It also integrates well with Python-to-C
+compilers such as :pypi:`Cython` and :RTD:`mypyc`.
 
 
 Documentation
 =============
 
-To begin using setuptools, see the :doc:`User Guide <userguide/index>`.
-
-To begin contributing to setuptools, see the :doc:`Developer Guide <development/index>`.
-
-
-
-Forum and Bug Tracker
-=====================
-
-Please use `GitHub Discussions`_ for questions and discussion about
-setuptools, and the `setuptools bug tracker`_ ONLY for issues you have
-confirmed via the forum are actual bugs, and which you have reduced to a minimal
-set of steps to reproduce.
-
-.. _GitHub Discussions: https://github.com/pypa/setuptools/discussions
-.. _setuptools bug tracker: https://github.com/pypa/setuptools/
-
-
-
+Check out our :doc:`User Guide </userguide/index>` for information on how to use ``setuptools``,
+and if you are interested in contributing to the project, please have a look on
+the :doc:`Development Guide </development/index>`.
 
 .. toctree::
    :maxdepth: 1
@@ -58,5 +44,18 @@ set of steps to reproduce.
    Backward compatibility & deprecated practice <deprecated/index>
    Changelog <history>
    artwork
+
+
+Forum and Bug Tracker
+=====================
+
+Please use `GitHub Discussions`_ for questions and discussion about
+setuptools, and the `setuptools bug tracker`_ ONLY for issues you have
+confirmed via the forum are actual bugs, and which you have reduced to a minimal
+set of steps to reproduce.
+
+.. _GitHub Discussions: https://github.com/pypa/setuptools/discussions
+.. _setuptools bug tracker: https://github.com/pypa/setuptools/
+
 
 .. tidelift-referral-banner::

--- a/docs/userguide/datafiles.rst
+++ b/docs/userguide/datafiles.rst
@@ -12,8 +12,9 @@ Setuptools focuses on this most common type of data files and offers three ways
 of specifying which files should be included in your packages, as described in
 the following sections.
 
-The default behaviour for ``setuptools`` will work well for pure Python packages, or packages with simple C extensions (that don't require
-any special C header). This page and :ref:`Controlling files in the distribution`
+The default behaviour for ``setuptools`` will work well for pure Python packages,
+or packages with simple C extensions (that don't require any special C header).
+This page and :ref:`Controlling files in the distribution`
 are about more complex scenarios when you want to include other types of files.
 
 include_package_data

--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -12,15 +12,6 @@ This means that, for the majority of the use cases, you don't have to create
 a ``setup.py`` file, which in turn, not only allows automation scenarios but
 also reduces boilerplate code in some cases.
 
-.. note::
-   If compatibility with legacy builds (i.e. those not using the :pep:`517` build API)
-   is desired, a ``setup.py`` file containing a ``setup()`` function call is
-   still required even if your configuration resides in ``setup.cfg``/``pyproject.toml``.
-   A simple script will suffice, for example::
-
-       from setuptools import setup
-       setup()
-
 .. _example-setup-config:
 
 .. code-block:: ini
@@ -88,6 +79,15 @@ Metadata and options are set in the config sections of the same name.
   order to cover common usecases.
 
 * Unknown keys are ignored.
+
+.. note::
+   If compatibility with legacy builds (i.e. those not using the :pep:`517` build API)
+   is desired, a ``setup.py`` file containing a ``setup()`` function call is
+   still required even if your configuration resides in ``setup.cfg``/``pyproject.toml``.
+   A simple script will suffice, for example::
+
+       from setuptools import setup
+       setup()
 
 
 Using a ``src/`` layout

--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -6,34 +6,20 @@ Configuring setuptools using ``setup.cfg`` files
 
 .. versionadded:: 30.3.0 (8 Dec 2016).
 
-Originally ``setuptools`` required all configuration options to be supplied
-as code to the ``setup()`` function in ``setup.py``.
-
-``Setup.cfg`` was introduced as a declarative alternative method to define
-a package's metadata and other options. After :pep:`621`, the Python
-community selected ``pyproject.toml`` as a standard declarative way of
-specifying *project metadata*., and these **replaced** setup.cfg files.
-
-This means that you can have a Python project with all build configuration
-specified in ``setup.cfg``/ ``pyproject.toml``, without a ``setup.py`` file,
-if you **can rely on** your project always being built by a :pep:`517`/:pep:`518`
-compatible frontend. This approach not only allows automation scenarios but
+``Setuptools`` allows using configuration files (usually :file:`setup.cfg`)
+to define a package’s metadata and other options in a declarative way.
+This means that, for the majority of the use cases, you don't have to create
+a ``setup.py`` file, which in turn, not only allows automation scenarios but
 also reduces boilerplate code in some cases.
 
-If compatibility with legacy builds (i.e. those not using the :pep:`517`
-build API) is desired, a ``setup.py`` file containing a ``setup()`` function
-call is still required even if your configuration resides in ``setup.cfg``/``pyproject.toml``.
+.. note::
+   If compatibility with legacy builds (i.e. those not using the :pep:`517` build API)
+   is desired, a ``setup.py`` file containing a ``setup()`` function call is
+   still required even if your configuration resides in ``setup.cfg``/``pyproject.toml``.
+   A simple script will suffice, for example::
 
-
-.. note:: TODO: inserted from "Building and Distributing Packages": is this still true?
-
-	versionadded:: 40.9.0
-
-	If ``setup.py`` is missing from the project directory when a :pep:`517`
-	build is invoked, ``setuptools`` emulates a dummy ``setup.py`` file containing
-	only a ``setuptools.setup()`` call.
-
-	Caveat: except for editable installs? see pyproject.toml page
+       from setuptools import setup
+       setup()
 
 .. _example-setup-config:
 

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -4,19 +4,7 @@
 Configuring setuptools using ``pyproject.toml`` files
 -----------------------------------------------------
 
-.. note:: New in 61.0.0
-
-.. important::
-   For the time being, ``pip`` still might require a ``setup.py`` file
-   to support :doc:`editable installs <pip:cli/pip_install>`.
-
-   A simple script will suffice, for example:
-
-   .. code-block:: python
-
-       from setuptools import setup
-
-       setup()
+.. versionadded:: 61.0.0 (24 Mar 2022)
 
 Starting with :pep:`621`, the Python community selected ``pyproject.toml`` as
 a standard way of specifying *project metadata*.
@@ -65,6 +53,18 @@ The ``project`` table contains metadata fields as described by
    my-script = "my_package.module:function"
 
    # ... other project metadata fields as specified in PEP 621
+
+.. important::
+   For the time being, ``pip`` still might require a ``setup.py`` file
+   to support :doc:`editable installs <pip:cli/pip_install>`.
+
+   A simple script will suffice, for example:
+
+   .. code-block:: python
+
+       from setuptools import setup
+
+       setup()
 
 .. _setuptools-table:
 


### PR DESCRIPTION
Hi @jacalata, thank you very much for the original PR in the setuptools docs.
I had a look and I would like to make some suggestions (implemented in this PR).

The main suggestions are:
- A fix for the news fragment (wrong PR/issue number and content). Maybe this is caused by 2 PRs being stacked together? We might have problems to merge this...
- A change for the redirect target. According to [the docs](https://documatt.gitlab.io/sphinx-reredirects/usage.html#usage) targets need to be fully qualified by a file extension
- A separated page for deprecated APIs (I have the impression that they will grow with time...)
  - I also added some alternatives for developers. 
- Some minor improvement of the frontpage, including:
  - I removed the "about" title because I think it is not needed
  - I reordered the ToC to be part of "documentation" because if we ever decide to un-hide it, I think that would be a better position.
- Restore the text in introductory section of the declarative config for `setup.cfg`
  - The main idea here is to avoid referring to how things used to be in the past and focus on how they are now.
  - I copied over some improvements (e.g. the `versionadded` directive) to the `pyproject.toml` configuration page.
  - I moved the warnings/info on both pages after the first example (I think it might be nicer this way?)
- A new deprecated page with some of the contents of the removed `setuptools.rst` file, telling a little bit about the origin of setuptools.

Please let me know your thoughts.

[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
